### PR TITLE
Include åäö in regex for highlighting

### DIFF
--- a/src/tiny-autocomplete-0.4.js
+++ b/src/tiny-autocomplete-0.4.js
@@ -316,7 +316,7 @@
       for(var i in v) {
         if(typeof(v[i]) == 'string' && i != 'template') {
           for(var j=0;j<words.length;j++) {
-            var word = words[j].trim().replace(/[^a-z0-9]/gi,''); // Remove non-alphanumerics
+            var word = words[j].trim().replace(/[^a-ö0-9]/gi,''); // Remove non-alphanumerics
             if(word.length > 0) {
               v[i] = v[i].replace( new RegExp("(" + word + ")" , 'gi'), "<strong>$1</strong>" );
             }


### PR DESCRIPTION
When searching for "Lördag" the word is not matched because it contains a character which is not matched by this regex `/[^a-z0-9]/gi`

Not sure if there is a better way to do it or if this may cause issues but it seems to work :rainbow:
