### PR TITLE
Added no results found message

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,20 @@ $('.autocomplete').tinyAutocomplete({ templateMethod: _.template });
 You can use this to override Tiny Autocomplete's cheap-and-cheerful templating function with something more powerful. The template function takes two arguments. The first argument is the template itself (which is a string) and the second is the object that Tiny Autocomplete passes in to the template to render it. You can use underscore's "template" method as a drop-in replacement and there are probably others that work the same way.
 
 
+#### showNoResults:
+```javascript
+$('.autocomplete').tinyAutocomplete({ showNoResults: true });
+```
+By default Tiny Autocomplete will not show "No results" message when no data is found. Enabling this option will display the "No results found for foo" message.
+
+
+#### noResultsTemplate:
+```javascript
+$('.autocomplete').tinyAutocomplete({ noResultsTemplate: '<li class="autocomplete-item">No results for {{title}}</li>' });
+```
+Template for the "No results found" message. Will only be shown if `showNoResults` option is enabled. Uses same templating engine as the other templates.
+
+
 ### Global defaults
 If you want to, you can set global options for all your autocompletes by setting them on the $.tinyAutocomplete.defaults object, like so:
 ```javascript

--- a/grouped.html
+++ b/grouped.html
@@ -20,6 +20,7 @@
       url: '/data/grouped.json',
       grouped: true,
       maxItems: 2,
+      showNoResults: true,
       lastItemTemplate: '<li class="autocomplete-item autocomplete-item-last">Show all results for "{{title}}"</li>',
       onSelect: function(el, val) {
         if(val == null) {

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     $('#autocomplete-0').tinyAutocomplete({
       url: '/data/flat.json',
       maxItems: 7,
+      showNoResults: true,
       onSelect: function(el, val) {
         if(val == null) {
           $('.results').html('All results for "' + $(this).val() + '"" would go here');

--- a/local.html
+++ b/local.html
@@ -123,6 +123,7 @@
   <script>
     $('#autocomplete-0').tinyAutocomplete({
       data: birds,
+      showNoResults: true,
       lastItemTemplate: '<li class="autocomplete-item autocomplete-item-last">Show all results for "{{title}}"</li>',
       onSelect: function(el, val) {
         if(val == null) {

--- a/src/tiny-autocomplete.js
+++ b/src/tiny-autocomplete.js
@@ -246,7 +246,8 @@
       if(i == null) {
         return $();
       }
-      return $('.autocomplete-item').eq(i);
+
+      return this.el.find('.autocomplete-item').eq(i);
     },
 
     /**

--- a/src/tiny-autocomplete.js
+++ b/src/tiny-autocomplete.js
@@ -34,7 +34,9 @@
       closeOnSelect: true,
       groupContentName: '.autocomplete-items',
       groupTemplate: '<li class="autocomplete-group"><span class="autocomplete-group-header">{{title}}</span><ul class="autocomplete-items" /></li>',
-      itemTemplate: '<li class="autocomplete-item">{{title}}</li>'
+      itemTemplate: '<li class="autocomplete-item">{{title}}</li>',
+      showNoResults: false,
+      noResultsTemplate: '<li class="autocomplete-item">No results for {{title}}</li>'
     },
 
     /**
@@ -392,6 +394,15 @@
     },
 
     /**
+     * If there's a "no results found for..." item, this function
+     * gets called.
+     * @return {null}
+     */
+    renderNoResults: function() {
+      this.list.append( this.settings.templateMethod( this.settings.noResultsTemplate, {title: this.field.val()} ) );
+    },
+
+    /**
      * Removes list from DOM and resets state.
      * @return {null}
      */
@@ -478,6 +489,13 @@
         this.renderItemsFlat();
       }
 
+      // If no results, render no results message, if applicable
+      if(!this.items.length) {
+        if(this.settings.showNoResults) {
+          this.renderNoResults();
+        }
+      }
+
       // Render last item, if applicable
       if(this.settings.lastItemTemplate) {
         this.renderLastItem();
@@ -498,6 +516,7 @@
         this.request( this.field.val() );
       }
       if(this.field.val() == '') {
+        this.lastSearch = '';
         this.closeList();
       }
     },


### PR DESCRIPTION
This pr contains three changes, the main change, no results found message and a minor fixes.

* Added `No results found`
* Improved functionality with multiple autocompletes in same page
* Clearing `this.lastSearch` variable when value is empty