### PR TITLE
Preload data

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,30 @@ $('.autocomplete').tinyAutocomplete({ noResultsTemplate: '<li class="autocomplet
 Template for the "No results found" message. Will only be shown if `showNoResults` option is enabled. Uses same templating engine as the other templates.
 
 
+#### preloadData:
+```javascript
+$('.autocomplete').tinyAutocomplete({ preloadData: [...] });
+```
+Similar to `data` option, but the preloaded data will be shown immediately. No need to type anything.
+After typing, the default behavior kicks in and autocomplete is then using data from `data` or from `url`.
+
+
+#### preloadUrl:
+```javascript
+$('.autocomplete').tinyAutocomplete({ preloadUrl: 'http://www.example.com/search' });
+```
+Similar to `url` option, but the preloaded data will be fetched and shown immediately. No need to type anything.
+After typing, the default behavior kicks in and autocomplete is then using data from `data` or from `url`.
+
+
+#### formatDataFunction:
+```javascript
+$('.autocomplete').tinyAutocomplete({ formatDataFunction: function(json) {} });
+```
+By setting this option, you can format the data how ever you like, before it is passed to the renderer.
+Works in very similar fashion to the `receivedata` event, only difference is that it is an option passed to autocomplete, instead of being an event.
+
+
 ### Global defaults
 If you want to, you can set global options for all your autocompletes by setting them on the $.tinyAutocomplete.defaults object, like so:
 ```javascript

--- a/preload.html
+++ b/preload.html
@@ -1,0 +1,141 @@
+<html>
+<head>
+  <title>Autocomplete</title>
+  <link rel="stylesheet" href="css/tiny-autocomplete.css" />
+  <link rel="stylesheet" href="css/autocomplete-demos.css" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+</head>
+<body>
+  <h1>Tiny-autocomplete demo (preload)</h1>
+  <input id="autocomplete-0" type="text" name="autocomplete-0" />
+  <div class="results"></div>
+
+  <script src="lib/jquery-2.0.2.js"></script>
+  <script src="src/tiny-autocomplete.js"></script>
+
+  <script>
+    var birds = [
+      {"title":"Southern Screamer", "id":1},
+      {"title":"Horned Screamer", "id":2},
+      {"title":"Magpie-goose", "id":3},
+      {"title":"Swan Goose", "id":4},
+      {"title":"White-faced Whistling Duck", "id":5},
+      {"title":"Greater White-fronted Goose", "id":6},
+      {"title":"Greylag Goose", "id":7},
+      {"title":"Bar-headed Goose", "id":8},
+      {"title":"Snow Goose", "id":9},
+      {"title":"Nene", "id":10},
+      {"title":"Canada Goose", "id":11},
+      {"title":"Brent Goose (Brant)", "id":12},
+      {"title":"Barnacle Goose", "id":13},
+      {"title":"Canada Goose", "id":14},
+      {"title":"Cackling Goose", "id":15},
+      {"title":"Red-breasted Goose", "id":16},
+      {"title":"Hawaiian Goose", "id":17},
+      {"title":"Woods-walking Goose", "id":18},
+      {"title":"Black Swan", "id":19},
+      {"title":"Mute Swan", "id":20},
+      {"title":"Whooper Swan", "id":21},
+      {"title":"Tundra Swan", "id":22},
+      {"title":"Magellanic Flightless Steamer Duck", "id":23},
+      {"title":"Spur-winged Goose", "id":24},
+      {"title":"Egyptian Goose", "id":25},
+      {"title":"Blue Duck", "id":26},
+      {"title":"Orinoco Goose", "id":27},
+      {"title":"Andean Goose", "id":28},
+      {"title":"African Pygmy Goose", "id":29},
+      {"title":"Common Shelduck", "id":30},
+      {"title":"Pink-eared Duck", "id":31},
+      {"title":"Muscovy Duck", "id":32},
+      {"title":"Wood Duck", "id":33},
+      {"title":"Mandarin Duck", "id":34},
+      {"title":"Gadwall", "id":35},
+      {"title":"American Wigeon", "id":36},
+      {"title":"Mallard", "id":37},
+      {"title":"Northern Shoveler", "id":38},
+      {"title":"Brown Teal", "id":39},
+      {"title":"Northern Pintail", "id":40},
+      {"title":"Common Teal", "id":41},
+      {"title":"Marbled Duck", "id":42},
+      {"title":"Common Pochard", "id":43},
+      {"title":"Tufted Duck", "id":44},
+      {"title":"Greater Scaup", "id":45},
+      {"title":"King Eider", "id":46},
+      {"title":"Harlequin Duck", "id":47},
+      {"title":"Black Scoter", "id":48},
+      {"title":"Long-tailed Duck", "id":49},
+      {"title":"Common Goldeneye", "id":50},
+      {"title":"Smew", "id":51},
+      {"title":"Common Merganser", "id":52},
+      {"title":"Black-headed Duck", "id":53},
+      {"title":"Ruddy Duck", "id":54},
+      {"title":"Musk Duck", "id":55},
+      {"title":"Emperor Penguin", "id":56},
+      {"title":"King Penguin", "id":57},
+      {"title":"Gentoo Penguin", "id":58},
+      {"title":"Adelie Penguin", "id":59},
+      {"title":"Rockhopper penguin", "id":60},
+      {"title":"Macaroni Penguin", "id":61},
+      {"title":"Yellow-eyed Penguin", "id":62},
+      {"title":"Fairy Penguin", "id":63},
+      {"title":"African Penguin", "id":64},
+      {"title":"Magellanic Penguin", "id":65},
+      {"title":"Galápagos Penguin", "id":66},
+      {"title":"Great Auk (extinct)", "id":67},
+      {"title":"Baba penguin", "id":68},
+      {"title":"Black-throated Diver", "id":69},
+      {"title":"Red-throated Diver (Red-throated Loon)", "id":70},
+      {"title":"Great Northern Diver (Common Loon)", "id":71},
+      {"title":"Sooty Albatross", "id":72},
+      {"title":"Black-browed Albatross", "id":73},
+      {"title":"Laysan Albatross", "id":74},
+      {"title":"Royal Albatross", "id":75},
+      {"title":"Wandering Albatross", "id":76},
+      {"title":"Southern Giant Petrel", "id":77},
+      {"title":"Antarctic Petrel", "id":78},
+      {"title":"Northern Fulmar", "id":79},
+      {"title":"Snow Petrel", "id":80},
+      {"title":"Fairy Prion", "id":81},
+      {"title":"Cook's Petrel", "id":82},
+      {"title":"Antarctic Prion", "id":83},
+      {"title":"Cahow", "id":84},
+      {"title":"Cape Petrel", "id":85},
+      {"title":"Cory's Shearwater", "id":86},
+      {"title":"Sooty Shearwater", "id":87},
+      {"title":"Short-tailed Shearwater", "id":88},
+      {"title":"Manx Shearwater", "id":89},
+      {"title":"Wilson's Storm-petrel", "id":90},
+      {"title":"European Storm-petrel", "id":91},
+      {"title":"Common Diving-petrel", "id":92},
+      {"title":"Black-bellied Storm-petrel", "id":93},
+      {"title":"Ashy Storm-petrel", "id":94},
+      {"title":"Leach's Storm-petrel", "id":95},
+      {"title":"Little Grebe", "id":96},
+      {"title":"Australasian Grebe", "id":97},
+      {"title":"White-tufted Grebe", "id":98},
+      {"title":"Hoary-headed Grebe", "id":99},
+      {"title":"Clark's Grebe", "id":100}
+    ];
+  </script>
+
+  <script>
+    $('#autocomplete-0').tinyAutocomplete({
+      url: '/data/flat.json',
+      preloadData: birds,
+      showNoResults: true,
+      lastItemTemplate: '<li class="autocomplete-item autocomplete-item-last">Show all results for "{{title}}"</li>',
+      onSelect: function(el, val) {
+        if(val == null) {
+          $('.results').html('All results for "' + $(this).val() + '" would go here');
+        }
+        else {
+          $(this).val( val.title );
+          $('.results').html('<h1>' + val.title + '</h1>');
+        }
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This pr contains couple of additions and some fixes.
- `preloadData` option added to show some preloaded data immediately
- `preloadUrl` option added to fetch and display some preloaded data immediately
  - Both these options work internally similar to `data` and `url` options
- Fixed template method, it was printing `undefined` to the suggestions when it couldn't find a match
