### PR TITLE
Update tiny-autocomplete.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ Change template for an item group, when using grouped view. Default is
 ```
 Make sure your `groupContentName` matches the ul class!
 
+#### wrapClasses:
+```javascript
+$('.autocomplete').tinyAutocomplete({ wrapClasses: 'autocomplete no-autoinit'});
+```
+To add classes to the list created by tinyAutocomplete, use wrapClasses.  The default is "autocomplete".  This is useful, for example, where using tinyAutocomplete with Materializecss which adds it's own formatting where it sees an autocomplete.  Adding the class no-autoinit will prevent materialize from doing this.
+
 
 #### groupContentName:
 ```javascript

--- a/src/tiny-autocomplete.js
+++ b/src/tiny-autocomplete.js
@@ -37,7 +37,8 @@
       groupTemplate: '<li class="autocomplete-group"><span class="autocomplete-group-header">{{title}}</span><ul class="autocomplete-items" /></li>',
       itemTemplate: '<li class="autocomplete-item">{{title}}</li>',
       showNoResults: false,
-      noResultsTemplate: '<li class="autocomplete-item">No results for {{title}}</li>'
+      noResultsTemplate: '<li class="autocomplete-item">No results for {{title}}</li>', 
+      wrapClasses: "autocomplete"
     },
 
     /**
@@ -147,7 +148,7 @@
     setupMarkup: function() {
       this.field.addClass('autocomplete-field');
       this.field.attr('autocomplete', 'off');
-      this.field.wrap('<div class="autocomplete" />');
+      this.field.wrap('<div class="' + this.settings.wrapClasses + '" />');
       this.el = this.field.parent();
     },
 


### PR DESCRIPTION
Allows for overriding autocomplete or additional classes on outer wrapper.
Defaults to "autocomplete"
This is required to use with materializecss where you need to add the no-autoinit class otherwise you get the error Cannot set property 'tabIndex' of null when autoInit is run.

Adding this line to autocomplete definition fixes it::

      wrapClasses: "autocomplete no-autoinit",