### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js: node
 cache: npm
+addons:
+  apt:
+    packages:
+    - libgconf-2-4
+      # required in the latest Travis version:
+      # https://github.com/cypress-io/cypress/issues/4069

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,12 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "arch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -158,12 +164,12 @@
       "dev": true
     },
     "async": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.4.0.tgz",
-      "integrity": "sha1-SZAgDxjqW4N8LMT4wDGmmFw4VhE=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "^4.17.10"
       }
     },
     "asynckit": {
@@ -347,9 +353,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -411,41 +417,52 @@
       }
     },
     "cypress": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.2.0.tgz",
-      "integrity": "sha512-PN0wz6x634QyNL56/voTzJoeScDfwtecvSfFTHfv5MkHuECVSR4VQcEZTvYtKWln3CMBMUkWbBKPIwwu2+a/kw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.4.1.tgz",
+      "integrity": "sha512-1HBS7t9XXzkt6QHbwfirWYty8vzxNMawGj1yI+Fu6C3/VZJ8UtUngMW6layqwYZzLTZV8tiDpdCNBypn78V4Dg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
         "@cypress/xvfb": "1.2.4",
+        "arch": "2.1.1",
         "bluebird": "3.5.0",
         "cachedir": "1.3.0",
         "chalk": "2.4.2",
         "check-more-types": "2.24.0",
         "commander": "2.15.1",
         "common-tags": "1.8.0",
-        "debug": "3.1.0",
+        "debug": "3.2.6",
         "execa": "0.10.0",
         "executable": "4.1.1",
         "extract-zip": "1.6.7",
-        "fs-extra": "4.0.1",
-        "getos": "3.1.0",
-        "glob": "7.1.3",
+        "fs-extra": "5.0.0",
+        "getos": "3.1.1",
         "is-ci": "1.2.1",
         "is-installed-globally": "0.1.0",
         "lazy-ass": "1.6.0",
         "listr": "0.12.0",
-        "lodash": "4.17.11",
+        "lodash": "4.17.15",
         "log-symbols": "2.2.0",
         "minimist": "1.2.0",
         "moment": "2.24.0",
         "ramda": "0.24.1",
         "request": "2.88.0",
-        "request-progress": "0.4.0",
+        "request-progress": "3.0.0",
         "supports-color": "5.5.0",
-        "tmp": "0.0.33",
+        "tmp": "0.1.0",
         "url": "0.11.0",
         "yauzl": "2.10.0"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^2.6.3"
+          }
+        }
       }
     },
     "dashdash": {
@@ -464,12 +481,20 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "deep-is": {
@@ -513,9 +538,9 @@
       }
     },
     "ecstatic": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.1.tgz",
-      "integrity": "sha512-/rrctvxZ78HMI/tPIsqdvFKHHscxR3IJuKrZI2ZoUgkt2SiufyLFBmcco+aqQBIu6P1qBsUNG3drAAGLx80vTQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
       "dev": true,
       "requires": {
         "he": "^1.1.1",
@@ -943,13 +968,13 @@
       }
     },
     "fs-extra": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
-      "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "jsonfile": "^3.0.0",
+        "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
     },
@@ -984,12 +1009,12 @@
       "dev": true
     },
     "getos": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.0.tgz",
-      "integrity": "sha512-i9vrxtDu5DlLVFcrbqUqGWYlZN/zZ4pGMICCAcZoYsX3JA54nYp8r5EThw5K+m2q3wszkx4Th746JstspB0H4Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.1.tgz",
+      "integrity": "sha512-oUP1rnEhAr97rkitiszGP9EgDVYnmchgFzfqRzSkgtfv7ai6tEi7Ko8GgjNXts7VLWEqrTWyhsOKLe5C5b/Zkg==",
       "dev": true,
       "requires": {
-        "async": "2.4.0"
+        "async": "2.6.1"
       }
     },
     "getpass": {
@@ -1490,9 +1515,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -1698,9 +1723,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.once": {
@@ -1741,18 +1766,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.38.0"
+        "mime-db": "1.40.0"
       }
     },
     "mimic-fn": {
@@ -1821,12 +1846,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
-    "node-eta": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/node-eta/-/node-eta-0.1.1.tgz",
-      "integrity": "sha1-QGYQmzk3HHYccrfr2pqeoKXeEh8=",
       "dev": true
     },
     "normalize-package-data": {
@@ -2154,9 +2173,9 @@
       }
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "progress": {
@@ -2166,9 +2185,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
       "dev": true
     },
     "punycode": {
@@ -2265,13 +2284,12 @@
       }
     },
     "request-progress": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.4.0.tgz",
-      "integrity": "sha1-wZVOOQhqqFJpxWYLzuAUKmpw1+c=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+      "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
       "dev": true,
       "requires": {
-        "node-eta": "^0.1.1",
-        "throttleit": "^0.0.2"
+        "throttleit": "^1.0.0"
       }
     },
     "requires-port": {
@@ -2596,9 +2614,9 @@
       "dev": true
     },
     "throttleit": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/varvet/tiny-autocomplete#readme",
   "devDependencies": {
-    "cypress": "^3.2.0",
+    "cypress": "^3.4.1",
     "eslint": "^5.15.3",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-prettier": "^3.0.1",


### PR DESCRIPTION
NOTE: I had to add a package on Travis to get this building on CI - is that the right way to do it?

Github notified us about two packages with significant vulnerabilities:

 - ecstatic WS-2019-0066
 - lodash CVE-2019-10744

After running `npm install` on a fresh installation, we got the following
message:

    found 6 high severity vulnerabilities
      run `npm audit fix` to fix them, or `npm audit` for details

After running `npm audit fix` we got:

    added 3 packages from 2 contributors, removed 1 package and updated 15 packages in 88.466s
      fixed 6 of 6 vulnerabilities in 603 scanned packages

...so it seems to have updated more than just the two which Github told us
about, but none of them seem to be major version updates, and the test
suite still passes, so I feel OK about this.