### PR TITLE
Mobile settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ Template for the "No results found" message. Will only be shown if `showNoResult
 $(".autocomplete").tinyAutocomplete({ maxItemsOnMobile: 5 });
 ```
 
-Limit the number of item when screen width is smaller than mobileWidth setting (which is by default 700px).
+Limit the number of items displayed when the screen width is smaller than the mobileWidth setting (which is by default 700px).
+See [mobileWidth](#mobilewidth).
 
 By default Tiny Autocomplete will set maxItemsOnMobile to **3**
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,25 @@ $(".autocomplete").tinyAutocomplete({
 
 Template for the "No results found" message. Will only be shown if `showNoResults` option is enabled. Uses same templating engine as the other templates.
 
+### maxItemsOnMobile
+```javascript
+$(".autocomplete").tinyAutocomplete({ maxItemsOnMobile: 5 });
+```
+
+Limit the number of item when screen width is smaller than mobileWidth setting (which is by default 700px).
+
+By default Tiny Autocomplete will set maxItemsOnMobile to **3**
+
+### mobileWidth
+```javascript
+$(".autocomplete").tinyAutocomplete({ mobileWidth: 500 });
+```
+
+See [maxItemsOnMobile](#maxitemsonmobile)
+
+By default Tiny Autocomplete will set mobileWidth to **700**
+
+
 ### Global defaults
 
 If you want to, you can set global options for all your autocompletes by setting them on the \$.tinyAutocomplete.defaults object, like so:

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ $(".autocomplete").tinyAutocomplete({
 
 Template for the "No results found" message. Will only be shown if `showNoResults` option is enabled. Uses same templating engine as the other templates.
 
-### maxItemsOnMobile
+#### maxItemsOnMobile
 ```javascript
 $(".autocomplete").tinyAutocomplete({ maxItemsOnMobile: 5 });
 ```
@@ -261,7 +261,7 @@ Limit the number of item when screen width is smaller than mobileWidth setting (
 
 By default Tiny Autocomplete will set maxItemsOnMobile to **3**
 
-### mobileWidth
+#### mobileWidth
 ```javascript
 $(".autocomplete").tinyAutocomplete({ mobileWidth: 500 });
 ```

--- a/src/tiny-autocomplete.js
+++ b/src/tiny-autocomplete.js
@@ -32,6 +32,8 @@ var factory = function($, window) {
       method: "get",
       scrollOnFocus: "auto",
       maxItems: 100,
+      maxItemsOnMobile: 3,
+      mobileWidth: 700,
       keyboardDelay: 300,
       lastItemTemplate: null,
       closeOnSelect: true,
@@ -107,8 +109,9 @@ var factory = function($, window) {
       // We might be on a mobile device and have little in the way of
       // vertical real estate to work with. Cap it! This check needs a
       // bit more intelligence to it.
-      if (window.innerWidth < 700) {
-        this.settings.maxItems = Math.min(this.settings.maxItems, 3);
+      this.settings.maxItemsOnLarge = this.settings.maxItems;
+      if (window.innerWidth < this.settings.mobileWidth && this.settings.maxItemsOnMobile !== null) {
+        this.settings.maxItems = Math.min(this.settings.maxItems, this.settings.maxItemsOnMobile);
       }
 
       // Using local data or remote url?
@@ -142,6 +145,15 @@ var factory = function($, window) {
       );
 
       this.el.on("blur", ".autocomplete-field", $.proxy(this.closeList, this));
+
+      // Update maxItems when window size change
+      $(window).resize(this.debounce(() => {
+        if (window.innerWidth < this.settings.mobileWidth && this.settings.maxItemsOnMobile !== null) {
+          this.settings.maxItems = Math.min(this.settings.maxItems, this.settings.maxItemsOnMobile);
+        }else{
+          this.settings.maxItems = this.settings.maxItemsOnLarge;
+        }
+      }, 250));
 
       // Scroll to field if we're on a small device, we need that
       // screen real estate!


### PR DESCRIPTION
### Added new settings: 

- **maxItemsOnMobile** _int_ : allow you to change the number of items displayed when you are on a mobile, default is set to 3.
e.g `$(".autocomplete").tinyAutocomplete({ maxItemsOnMobile: 5 });`

- **mobileWidth** _int_ : allow you to say at what width the screen is considered as a "mobile", default is set to 700 px.
e.g `$(".autocomplete").tinyAutocomplete({ mobileWidth: 500 });`

This was hard-coded before :
>        if (window.innerWidth < 700) {
>           this.settings.maxItems = Math.min(this.settings.maxItems, 3);
>        }

Also added a window resize event to adapt the number of items displayed based on the new window size.
